### PR TITLE
feat: support Vite dynamic import functions with preloading

### DIFF
--- a/lib/retry.test.ts
+++ b/lib/retry.test.ts
@@ -66,7 +66,7 @@ describe("createDynamicImportWithRetry bust the cache of a module using the curr
 
     const /* ignored */ _promise = dynamicImportWithRetry(
         originalImport as any
-      ).catch(console.log);
+      ).catch(logger);
     await clock.advanceTimersByTimeAsync(1000);
 
     expect(importStubUsedInRetries).toHaveBeenCalledTimes(2);

--- a/lib/retry.test.ts
+++ b/lib/retry.test.ts
@@ -21,11 +21,17 @@ describe("path parsing of importer function", () => {
     // @ts-ignore
     return import("../some-module3");
   };
+  const viteImporterWithPreloadedDeps = function() { }
+  // Vite can wrap dynamic import functions into something like the following
+  viteImporterWithPreloadedDeps.toString = function() {
+    return `()=>H(()=>import("./NeedsFooAndBar.js"),["assets/foo.js","assets/bar.js"])`
+  }
 
   it("should work", () => {
     expect(parseBody(importer1)).toEqual("./some-module1");
     expect(parseBody(importer2)).toEqual("some-module2");
     expect(parseBody(importer3)).toEqual("../some-module3");
+    expect(parseBody(viteImporterWithPreloadedDeps)).toEqual("./NeedsFooAndBar.js");
   });
 });
 
@@ -60,7 +66,7 @@ describe("createDynamicImportWithRetry bust the cache of a module using the curr
 
     const /* ignored */ _promise = dynamicImportWithRetry(
         originalImport as any
-      );
+      ).catch(console.log);
     await clock.advanceTimersByTimeAsync(1000);
 
     expect(importStubUsedInRetries).toHaveBeenCalledTimes(2);

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -8,7 +8,7 @@ type PositiveInteger<T extends number> = `${T}` extends
 const noop = () => {};
 
 const identity = (e: any) => e;
-const uriOrRelativePathRegex = /"((\w+:(\/?\/?))?[^\s]+)"/;
+const uriOrRelativePathRegex = /"((\w+:(\/?\/?))?[^\s,]+)"/;
 function parseModulePathFromImporterBody(importer: () => any): string | null {
   const fnString = importer.toString();
   const match = fnString.match(uriOrRelativePathRegex);


### PR DESCRIPTION
With a Vite build, the dynamic `import` function can be compiled down to something whose string representation looks like

```
()=>H(()=>import("./NeedsFooBar.js"),["assets/foo.js","assets/bar.js"])
```

This PR extends the retry regex so that it in this case matches only the path to the module, not the dependency array.

I've extended a test case to cover the fix. (As a side note, the other tests are failling when I run locally, but those are also failing against `main`. )